### PR TITLE
chore: adds flag to disable upgrade_dist

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -127,6 +127,9 @@ cis_purge_apt: false
 # Possible values are `tmp_systemd` or `fstab`-
 expected_tmp_mnt: fstab
 
+## 1.2.2.1 | Ensure updates, patches, and additional security software are installed
+cis_upgrade_dist: true
+
 ## Controls 1.4.1 - Boot password
 #
 # THIS VARIABLE SHOULD BE CHANGED AND INCORPORATED INTO VAULT

--- a/tasks/section_1/cis_1.2.x.yml
+++ b/tasks/section_1/cis_1.2.x.yml
@@ -69,6 +69,8 @@
   - name: 1.2.2.1 | Ensure updates, patches, and additional security software are installed | Upgrade all packages
     apt:
       upgrade: dist
+    when:
+    - cis_upgrade_dist
   tags:
   - level1-server
   - level1-workstation

--- a/tasks/section_7/cis_7.1.x.yml
+++ b/tasks/section_7/cis_7.1.x.yml
@@ -163,7 +163,6 @@
     file:
       path: '{{ item }}'
       mode: o-w
-      state: touch
     loop: "{{ world_writable_files.stdout_lines }}"
     when:
     - world_writable_files.stdout_lines is defined


### PR DESCRIPTION
Give the option to skip dist-upgrade as it may remove some packages

https://askubuntu.com/questions/81585/what-is-dist-upgrade-and-why-does-it-upgrade-more-than-upgrade